### PR TITLE
Fix for desync between username and token

### DIFF
--- a/RadiusAuthenticationAdapter/AuthenticationAdapter.cs
+++ b/RadiusAuthenticationAdapter/AuthenticationAdapter.cs
@@ -27,6 +27,8 @@ namespace RadiusAuthenticationAdapter
             // This is needed so we can access the UPN in TryEndAuthentication().
             this.identityClaim = identityClaim.Value;
 
+            context.Data.Add("userid", this.identityClaim);
+
             return new AdapterPresentation();
         }
 
@@ -131,7 +133,7 @@ namespace RadiusAuthenticationAdapter
                 throw new ExternalAuthenticationException(resMgr.GetString("Error_InvalidPIN", new System.Globalization.CultureInfo(context.Lcid)), context);
             }
             string pin = proofData.Properties["pin"].ToString();
-            string userName = this.identityClaim;
+            string userName = (string)context.Data["userid"];
 
             // Construct RADIUS auth request.
             var authPacket = radiusClient.Authenticate(userName, pin);
@@ -176,7 +178,7 @@ namespace RadiusAuthenticationAdapter
                 Logging.LogMessage(
                     "Processed authentication response." + Environment.NewLine +
                     "Packet Type: " + receivedPacket.PacketType.ToString() + Environment.NewLine +
-                    "User: " + this.identityClaim );
+                    "User: " + userName);
             }
 
             return result;


### PR DESCRIPTION
Fixed possible de-sync issue between the username and its token (for several consecutive users, the adapter would keep the first username for all requests, thus locking out the first user for the batch)

Example of the issue - user A and user B tries to connect in close proximity (several seconds apart):

- User A enters his username and token/pin
- RadiusAuthenticationAdapter issues Authenticate request to RADIUS with User A username and User A token/pin
- User A succeeds to authenticate and proceeds to desired resource
- User B enters his username and token/pin
- RadiusAuthenticationAdapter issues Authenticate request to RADIUS with **User A** username and User B token/pin
- User B receives "invalid credentials" error + User A gets 1 attempt towards token lockout
- If User B is persistent he can lock User A token

The solution provided is not to rely on stored identity claim and to pass it as a parameter towards ADFS and read it back before contacting the RADIUS.

The fix was tested in our environment for several weeks now and the issue has never reoccurred.
